### PR TITLE
Update ZA pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem 'puma', '~> 2.7'
 
 group :development, :test do
   gem 'pry'
+  gem 'pry-byebug'
   gem 'rspec'
   gem 'sass'
   gem 'timecop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ GEM
       sass (~> 3.4)
       thor (~> 0.19)
     builder (3.2.2)
+    byebug (8.2.2)
     celluloid (0.16.0)
       timers (~> 4.0.0)
     chunky_png (1.3.5)
@@ -120,6 +121,9 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pry-byebug (3.3.0)
+      byebug (~> 8.0)
+      pry (~> 0.10)
     ptools (1.3.3)
     puma (2.14.0)
     rack (1.6.4)
@@ -182,6 +186,7 @@ DEPENDENCIES
   middleman-search_engine_sitemap
   neat (~> 1.7.2)
   pry
+  pry-byebug
   puma (~> 2.7)
   rspec
   sass

--- a/config.rb
+++ b/config.rb
@@ -109,7 +109,7 @@ set :class_site_url, 'http://class.craftacademy.se'
 # Ignore folders with unused templates
 ignore 'elements/*'
 ignore 'not_in_use/*'
-#ignore 'case-studies/*' #as long as we don't present students
+# ignore 'case-studies/*' #as long as we don't present students
 
 # Redirects from old site urls
 redirect 'payments/new.html', to: config.apply_form_url
@@ -117,6 +117,7 @@ redirect 'apply.html', to: config.apply_form_url
 redirect 'apply-for-ronin.html', to: config.apply_form_url
 redirect 'blog.html', to: 'https://blog.craftacademy.se'
 redirect 'pretoria.html', to: 'south-africa.html'
+redirect 'south-africa.html', to: 'english/za/index.html'
 
 
 activate :deploy do |deploy|

--- a/config.rb
+++ b/config.rb
@@ -65,7 +65,7 @@ helpers CurrentPageHelper,
 
 helpers do
   def current_page_is_sa?
-    current_page.url.match(/pretoria|south-africa/)
+    current_page.url.match(/ pretoria|south-africa|za/)
   end
 
   def current_page_is_campaign_page?
@@ -73,7 +73,7 @@ helpers do
   end
 
   def international_pages?
-    current_page.url.match(/international|pretoria|south-africa/)
+    current_page.url.match(/international|pretoria|south-africa|za/)
   end
 end
 

--- a/source/.htaccess.apache.haml
+++ b/source/.htaccess.apache.haml
@@ -15,3 +15,18 @@ RewriteEngine On
 RewriteCond %{ENV:MM_COUNTRY_CODE} ^ZA$
 RewriteCond %{REQUEST_URI} !^/(south-africa|pretoria|sass|terms|privacy|international|javascripts|stylesheets|english|za)
 RewriteRule (.*) https://craftacademy.se/english/za [L]
+
+RewriteEngine On
+RewriteCond %{ENV:MM_COUNTRY_CODE} ^ZA$
+RewriteCond %{REQUEST_URI} ^/english
+RewriteRule (.*) https://craftacademy.se/english/za [L]
+
+RewriteEngine On
+RewriteCond %{ENV:MM_COUNTRY_CODE} ^ZA$
+RewriteCond %{REQUEST_URI} ^/english/about_us
+RewriteRule (.*) https://craftacademy.se/english/za/about_us [L]
+
+RewriteEngine On
+RewriteCond %{ENV:MM_COUNTRY_CODE} ^ZA$
+RewriteCond %{REQUEST_URI} ^/english/payment
+RewriteRule (.*) https://craftacademy.se/english/za/payment [L]

--- a/source/.htaccess.apache.haml
+++ b/source/.htaccess.apache.haml
@@ -13,5 +13,5 @@ RewriteRule (.*) https://craftacademy.se/$1 [R=301,L]
 
 RewriteEngine On
 RewriteCond %{ENV:MM_COUNTRY_CODE} ^ZA$
-RewriteCond %{REQUEST_URI} !^/(south-africa|pretoria|sass|terms|privacy|international|javascripts|stylesheets|english)
-RewriteRule (.*) https://craftacademy.se/south-africa [L]
+RewriteCond %{REQUEST_URI} !^/(south-africa|pretoria|sass|terms|privacy|international|javascripts|stylesheets|english|za)
+RewriteRule (.*) https://craftacademy.se/english/za [L]

--- a/source/english/partials/_apply.html.haml
+++ b/source/english/partials/_apply.html.haml
@@ -8,4 +8,7 @@
             We start a new course every eight weeks and continuously review and accept applicants. The application process can take up to two weeks, so please apply in time!
     .button-row
       %p
-        = link_to 'Apply Now', config.apply_form_url, class: 'button button--vertical button--large'
+        - if current_page_is_sa?
+          = link_to 'Apply Now', config.apply_sa_form_url, class: 'button button--vertical button--large'
+        - else
+          = link_to 'Apply Now', config.apply_form_url, class: 'button button--vertical button--large'

--- a/source/english/partials/_footer.html.haml
+++ b/source/english/partials/_footer.html.haml
@@ -1,39 +1,10 @@
 %footer{role: 'contentinfo'}
   .container
     .footer-links
-      %ul.column
-        %li
-          %h3 Social Media
-        %li
-          = link_to 'Facebook', 'https://www.facebook.com/craftacademysweden', target: '_blank'
-        %li
-          = link_to 'Twitter', 'https://twitter.com/CraftAcademySE', target: '_blank'
-        %li
-          = link_to 'YouTube', 'https://www.youtube.com/makersacademyse', target: '_blank'
-        %li
-          = link_to 'Blog', 'https://blog.craftacademy.se/', target: '_blank'
-      %ul.column
-        %li
-          %h3 Contact
-        %li
-          %address.vcard
-            %span.email
-              = link_to 'info@craftacademy.se', 'mailto:info@craftacademy.se'
-            .adr
-              %p
-                %span.org Craft Academy
-                %br
-                %span.org (Pragmatic Sweden AB)
-                %br
-                %span.street-address Chalmers Innovation,
-                %span.street-address Holtermansgatan 1D
-                %br
-                %span.postal-code 411 29
-                %span.locality Gothenburg,
-                %span.country-name Sweden
-                %br
-            .tel
-              = link_to '+46 (0)735 403500', 'tel:0735 453500'
+      - if current_page_is_sa?
+        = partial :'english/partials/footer_sa'
+      - else
+        = partial :'english/partials/footer_se'
       %ul.column
         %li
           %h3 Legal stuff

--- a/source/english/partials/_footer_sa.html.haml
+++ b/source/english/partials/_footer_sa.html.haml
@@ -1,0 +1,29 @@
+%ul.column
+  %li
+    %h3 Social media
+  %li
+    = link_to 'Facebook', 'https://www.facebook.com/CraftAcademySA/', target: '_blank'
+  %li
+    = link_to 'Blog', 'https://blog.craftacademy.se/', target: '_blank'
+%ul.column
+  %li
+    %h3 Contact
+  %li
+    %address.vcard
+      %span.email
+        = link_to 'diraulo@craftacademy.se', 'mailto:diraulo@craftacademy.se'
+      .adr
+        %p
+          %span.org Craft Academy
+          %br
+          %span.org
+            = link_to '(ThinkBots Pty Ltd.)', '//thinkbots.io'
+          %br
+          %span.street-address 634 Pretorius Street
+          %br
+          %span.postal-code 0083
+          %span.locality Pretoria,
+          %span.country-name South Africa
+          %br
+      .tel
+        = link_to '+27 (0) 71 071 5114', 'tel:+27710715114'

--- a/source/english/partials/_footer_se.html.haml
+++ b/source/english/partials/_footer_se.html.haml
@@ -1,0 +1,33 @@
+%ul.column
+  %li
+    %h3 Social Media
+  %li
+    = link_to 'Facebook', 'https://www.facebook.com/craftacademysweden', target: '_blank'
+  %li
+    = link_to 'Twitter', 'https://twitter.com/CraftAcademySE', target: '_blank'
+  %li
+    = link_to 'YouTube', 'https://www.youtube.com/makersacademyse', target: '_blank'
+  %li
+    = link_to 'Blog', 'https://blog.craftacademy.se/', target: '_blank'
+%ul.column
+  %li
+    %h3 Contact
+  %li
+    %address.vcard
+      %span.email
+        = link_to 'info@craftacademy.se', 'mailto:info@craftacademy.se'
+      .adr
+        %p
+          %span.org Craft Academy
+          %br
+          %span.org (Pragmatic Sweden AB)
+          %br
+          %span.street-address Chalmers Innovation,
+          %span.street-address Holtermansgatan 1D
+          %br
+          %span.postal-code 411 29
+          %span.locality Gothenburg,
+          %span.country-name Sweden
+          %br
+      .tel
+        = link_to '+46 (0)735 403500', 'tel:0735 453500'

--- a/source/english/partials/_intro_za.html.haml
+++ b/source/english/partials/_intro_za.html.haml
@@ -1,0 +1,17 @@
+%section
+  .container
+    %article
+      %h2 Learn to Code with Craft Academy
+      %h4 Start your next career with our intensive training
+      %p.copy--left
+        The tech industry has a huge effect on our lives, from how we talk to each other to how we learn. With Craft Academy, you can be a part of that inspiring world, and jump into a job market that is growing exponentially.
+      %p.copy--left
+        %strong
+          You do not need prior coding experience. You do not need to be a computer wiz or have studied computer science. You need to be hungry. We can teach anyone to code, if they are focused and committed.
+      %p.copy--left
+        We believe that traditional education teaches students to do well on tests, rather than give them actual knowledge and experience.
+        At Craft Academy, we provide neither grades nor diplomas. Instead, we help you develop the tools you need to be successful.
+        Our course is unique, not just in intensity, but in approach. We provide a structured daily learning plan, projects, assignments and challenges, and continually push your limits to achieve the fastest learning possible. All in twelve weeks.
+      -# %p.copy--left
+      -#   %strong
+      -#     With help from our network of Hiring Partners in Sweden and throughout Europe, we guide our students as they start their new careers.

--- a/source/english/partials/_nav_menu.html.haml
+++ b/source/english/partials/_nav_menu.html.haml
@@ -1,0 +1,16 @@
+%li{ class: current_if_current_page(current_page, '/english/about_us/') }
+  = link_to 'About Us'.mb_chars.upcase, '/english/about_us.html'
+%li{ class: current_if_current_page(current_page, '/english/employers/') }
+  = link_to 'Employers'.mb_chars.upcase, '/english/employers.html'
+%li{ class: current_if_current_page(current_page, '/english/curriculum/') }
+  = link_to 'Curriculum'.mb_chars.upcase, '/english/curriculum.html'
+%li{ class: current_if_current_page(current_page, '/english/payment/') }
+  = link_to 'Prices'.mb_chars.upcase, '/english/payment.html'
+%li
+  = link_to flag_image(:swedish), '/'
+- if current_page.url == '/english/employers/'
+  %li{ class: current_if_current_page(current_page, '/english/apply/') }
+    = link_to 'Hire'.mb_chars.upcase, config.hire_form_url, class: 'button button--vertical', target: '_blank'
+- else
+  %li{ class: current_if_current_page(current_page, '/english/apply/') }
+    = link_to 'Apply'.mb_chars.upcase, config.apply_form_url, class: 'button button--vertical'

--- a/source/english/partials/_nav_menu_mobile.html.haml
+++ b/source/english/partials/_nav_menu_mobile.html.haml
@@ -1,0 +1,12 @@
+%li{ class: current_if_current_page(current_page, '/') }
+  = link_to 'Home', '/english'
+%li{ class: current_if_current_page(current_page, '/english/about_us/') }
+  = link_to 'About Us', '/english/about_us.html'
+%li{ class: current_if_current_page(current_page, '/english/employers/') }
+  = link_to 'Employers', '/english/employers.html'
+%li{ class: current_if_current_page(current_page, '/english/curriculum/') }
+  = link_to 'Curriculum', '/english/curriculum.html'
+%li{ class: current_if_current_page(current_page, '/english/payment/') }
+  = link_to 'Prices'.mb_chars.upcase, '/english/payment.html'
+%li
+  = link_to flag_image(:swedish), '/'

--- a/source/english/partials/_nav_menu_mobile_sa.html.haml
+++ b/source/english/partials/_nav_menu_mobile_sa.html.haml
@@ -1,0 +1,12 @@
+%li{ class: current_if_current_page(current_page, '/') }
+  = link_to 'Home', '/english/za'
+%li{ class: current_if_current_page(current_page, '/english/za/about_us/') }
+  = link_to 'About Us', '/english/za/about_us.html'
+%li{ class: current_if_current_page(current_page, '/english/employers/') }
+  = link_to 'Employers', '/english/employers.html'
+%li{ class: current_if_current_page(current_page, '/english/curriculum/') }
+  = link_to 'Curriculum', '/english/curriculum.html'
+%li{ class: current_if_current_page(current_page, '/english/za/payment/') }
+  = link_to 'Prices'.mb_chars.upcase, '/english/za/payment.html'
+%li
+  = link_to flag_image(:swedish), '/'

--- a/source/english/partials/_nav_menu_sa.html.haml
+++ b/source/english/partials/_nav_menu_sa.html.haml
@@ -1,0 +1,16 @@
+%li{ class: current_if_current_page(current_page, '/english/za/about_us/') }
+  = link_to 'About Us'.mb_chars.upcase, '/english/za/about_us.html'
+%li{ class: current_if_current_page(current_page, '/english/employers/') }
+  = link_to 'Employers'.mb_chars.upcase, '/english/employers.html'
+%li{ class: current_if_current_page(current_page, '/english/curriculum/') }
+  = link_to 'Curriculum'.mb_chars.upcase, '/english/curriculum.html'
+%li{ class: current_if_current_page(current_page, '/english/za/payment/') }
+  = link_to 'Prices'.mb_chars.upcase, '/english/za/payment.html'
+%li
+  = link_to flag_image(:swedish), '/'
+- if current_page.url == '/english/employers/'
+  %li{ class: current_if_current_page(current_page, '/english/apply/') }
+    = link_to 'Hire'.mb_chars.upcase, config.hire_form_url, class: 'button button--vertical', target: '_blank'
+- else
+  %li{ class: current_if_current_page(current_page, '/english/apply/') }
+    = link_to 'Apply'.mb_chars.upcase, config.apply_sa_form_url, class: 'button button--vertical'

--- a/source/english/partials/_navigation.html.haml
+++ b/source/english/partials/_navigation.html.haml
@@ -5,47 +5,16 @@
     .image--centered.image--small
       = image_tag 'logo/graphic_only_logo_white.png'
     %ul.navigation-menu
-      %li{ class: current_if_current_page(current_page, '/') }
-        = link_to 'Home', '/english'
-      %li{ class: current_if_current_page(current_page, '/english/about_us/') }
-        = link_to 'About Us', '/english/about_us.html'
-      %li{ class: current_if_current_page(current_page, '/english/employers/') }
-        = link_to 'Employers', '/english/employers.html'
-      %li{ class: current_if_current_page(current_page, '/english/curriculum/') }
-        = link_to 'Curriculum', '/english/curriculum.html'
-      %li{ class: current_if_current_page(current_page, '/english/payment/') }
-        = link_to 'Prices'.mb_chars.upcase, '/english/payment.html'
-      %li
-        = link_to flag_image(:swedish), '/'
+      - if current_page_is_sa?
+        = partial :'english/partials/nav_menu_mobile_sa'
+      - else
+        = partial :'english/partials/nav_menu_mobile'
 
 %header{class: 'navigation auto-hide', role: 'banner'}
   %nav{role: 'navigation'}
     = link_to image_tag('logo/ca_basic_logo_320x40.png'), '/english', class: 'image--brand'
     %ul.navigation-menu
       - if current_page_is_sa?
-        %li{ class: current_if_current_page(current_page, '/english/za/about_us/') }
-          = link_to 'About Us'.mb_chars.upcase, '/english/za/about_us.html'
+        = partial :'english/partials/nav_menu_sa'
       - else
-        %li{ class: current_if_current_page(current_page, '/english/about_us/') }
-          = link_to 'About Us'.mb_chars.upcase, '/english/about_us.html'
-      %li{ class: current_if_current_page(current_page, '/english/employers/') }
-        = link_to 'Employers'.mb_chars.upcase, '/english/employers.html'
-      %li
-        = link_to 'Curriculum'.mb_chars.upcase, '/english/curriculum.html'
-      - if current_page_is_sa?
-        %li{ class: current_if_current_page(current_page, '/english/za/payment/') }
-          = link_to 'Prices'.mb_chars.upcase, '/english/za/payment.html'
-      - else
-        %li{ class: current_if_current_page(current_page, '/english/payment/') }
-          = link_to 'Prices'.mb_chars.upcase, '/english/payment.html'
-      %li
-        = link_to flag_image(:swedish), '/'
-      - if current_page.url == '/english/employers/'
-        %li{ class: current_if_current_page(current_page, '/english/apply/') }
-          = link_to 'Hire'.mb_chars.upcase, config.hire_form_url, class: 'button button--vertical', target: '_blank'
-      - else
-        %li{ class: current_if_current_page(current_page, '/english/apply/') }
-          - if current_page_is_sa?
-            = link_to 'Apply'.mb_chars.upcase, config.apply_sa_form_url, class: 'button button--vertical'
-          - else
-            = link_to 'Apply'.mb_chars.upcase, config.apply_form_url, class: 'button button--vertical'
+        = partial :'english/partials/nav_menu'

--- a/source/english/partials/_navigation.html.haml
+++ b/source/english/partials/_navigation.html.haml
@@ -22,8 +22,12 @@
   %nav{role: 'navigation'}
     = link_to image_tag('logo/ca_basic_logo_320x40.png'), '/english', class: 'image--brand'
     %ul.navigation-menu
-      %li{ class: current_if_current_page(current_page, '/english/about_us/') }
-        = link_to 'About Us'.mb_chars.upcase, '/english/about_us.html'
+      - if current_page_is_sa?
+        %li{ class: current_if_current_page(current_page, '/english/za/about_us/') }
+          = link_to 'About Us'.mb_chars.upcase, '/english/za/about_us.html'
+      - else
+        %li{ class: current_if_current_page(current_page, '/english/about_us/') }
+          = link_to 'About Us'.mb_chars.upcase, '/english/about_us.html'
       %li{ class: current_if_current_page(current_page, '/english/employers/') }
         = link_to 'Employers'.mb_chars.upcase, '/english/employers.html'
       %li

--- a/source/english/partials/_navigation.html.haml
+++ b/source/english/partials/_navigation.html.haml
@@ -14,7 +14,7 @@
       %li{ class: current_if_current_page(current_page, '/english/curriculum/') }
         = link_to 'Curriculum', '/english/curriculum.html'
       %li{ class: current_if_current_page(current_page, '/english/payment/') }
-        = link_to 'Investment'.mb_chars.upcase, '/english/payment.html'
+        = link_to 'Prices'.mb_chars.upcase, '/english/payment.html'
       %li
         = link_to flag_image(:swedish), '/'
 

--- a/source/english/partials/_navigation.html.haml
+++ b/source/english/partials/_navigation.html.haml
@@ -28,8 +28,12 @@
         = link_to 'Employers'.mb_chars.upcase, '/english/employers.html'
       %li
         = link_to 'Curriculum'.mb_chars.upcase, '/english/curriculum.html'
-      %li{ class: current_if_current_page(current_page, '/english/payment/') }
-        = link_to 'Prices'.mb_chars.upcase, '/english/payment.html'
+      - if current_page_is_sa?
+        %li{ class: current_if_current_page(current_page, '/english/za/payment/') }
+          = link_to 'Prices'.mb_chars.upcase, '/english/za/payment.html'
+      - else
+        %li{ class: current_if_current_page(current_page, '/english/payment/') }
+          = link_to 'Prices'.mb_chars.upcase, '/english/payment.html'
       %li
         = link_to flag_image(:swedish), '/'
       - if current_page.url == '/english/employers/'
@@ -37,5 +41,7 @@
           = link_to 'Hire'.mb_chars.upcase, config.hire_form_url, class: 'button button--vertical', target: '_blank'
       - else
         %li{ class: current_if_current_page(current_page, '/english/apply/') }
-          = link_to 'Apply'.mb_chars.upcase, config.apply_form_url, class: 'button button--vertical'
-
+          - if current_page_is_sa?
+            = link_to 'Apply'.mb_chars.upcase, config.apply_sa_form_url, class: 'button button--vertical'
+          - else
+            = link_to 'Apply'.mb_chars.upcase, config.apply_form_url, class: 'button button--vertical'

--- a/source/english/za/about_us.html.haml
+++ b/source/english/za/about_us.html.haml
@@ -1,0 +1,21 @@
+- description 'Learn coding and web development in three months. Craft Academy is an intensive, practical and focused training where students learn programming in Ruby, Javascript, HTML5, and CSS, among others. We offer training on-location in Gothenburg, Stockholm, Pretoria and around the world by distance.'
+- title 'About Us'
+
+%section.hero-splash{style: "background-image: url(#{image_path('backgrounds/splash_3.jpg')});"}
+  .container
+    .centered-row
+      %h1 About Craft Academy
+      %p
+        %strong
+          Craft Academy is a twelve-week intensive course designed to take you from zero to junior programmer. We're a group of dedicated coaches with decades of coding experience.
+
+%hr
+%section
+  .container
+    %article
+      %h3 Our mission
+      %h4.copy--left We aim to provide our students with the most effective training possible to prepare them - in an incredibly short time - to join the technical workforce, or build their own advanced projects.
+      %p.copy--left There is a strong need for web developers in South Africa and throughout the world. We train programmers who not only write great code, but who understand the industry's conventions, problem solve with intention, and are ready to join the workforce and be a productive member of a team. We believe that coding is a craft, not just the symbols you put into a program. To that end, we teach an ambitious array of coding skills, introducing students to dozens of tools and two coding languages, but we also teach coding methods like Agile and Test-Driven Development. These practices mold developers who will thrive in the real world.
+
+= partial :'english/partials/full_graduates_en'
+= partial :'english/partials/apply'

--- a/source/english/za/index.html.haml
+++ b/source/english/za/index.html.haml
@@ -1,0 +1,16 @@
+- description 'Learn coding and web development in three months. Craft Academy is an intensive, practical and focused training where students learn programming in Ruby, Javascript, HTML5, and CSS, among others. We offer training on-location in Gothenburg and Stockholm and around the world by distance.'
+%section.hero-splash{style: "background-image: url(#{image_path('backgrounds/splash_1.jpg')});"}
+  .container
+    .centered-row
+      %h4.leader Are you ready to challenge yourself?
+      %h1
+        = 'Coding as a craft in twelve weeks'.html_safe
+      %p{style: 'max-width: 29em;'}
+        %strong
+          With Craft Academy, you'll learn web development in an exciting, fast-paced environment and get help to find your first job or build your own project.
+
+= partial :'../partials/intro_za'
+= partial :'../partials/full_graduates_en'
+= partial :'../partials/who_is_it_for'
+= partial :'../partials/course_dates', locals: { language: :en }
+= partial :'../partials/apply' # This should be in the footer

--- a/source/english/za/payment.html.haml
+++ b/source/english/za/payment.html.haml
@@ -1,0 +1,28 @@
+- description 'Our prices - Base Price for Craft Academy Bootcamp is 35 000 ZAR.'
+%section.hero-splash{style: "background-image: url(#{image_path('backgrounds/splash_4.jpg')});"}
+  .container
+    .centered-row
+      %h1 Investment
+      %p
+        %strong
+          Enrolling in the Craft Academy bootcamp is an investment in your future. It is the quickest way to jump-start a career in software development; one of the fastest and most efficient ways to change your life.
+%section
+  .container
+    .centered-row
+      %h4.leader Craft Academy
+      %h2 Course Fees
+      %h4
+        The base price for Craft Academy bootcamp is 35 000 ZAR
+      .three-width-row
+        .column
+          %h3.copy--left Everything included
+          %p.copy--left Your course fees include all instruction, materials, and continued support before and after the bootcamp with technical and career assistance. We provide all the necessary tools to develop efficiently - software licenses, a functional and ergonomic work environment.
+        .column
+          %h3.copy--left Female participants
+          %p.copy--left We also proudly offer a 10% discount to female bootcamp participants. Our industry needs more female developers and we want to do everything we can to help women succeed on their coding journey.
+      %p.copy--left
+        Finances shouldn't stop anyone from fulfilling their dream of becoming a programmer. We encourage everyone to contact us to discuss payment options, including our flexible deposit and payment schedule.
+      %p.copy--left
+        A new cohort starts every eight weeks. Will you start your career as a junior developer with us?
+
+= partial :'/english/partials/apply'


### PR DESCRIPTION
- Create `/english/za` to house all SA specific pages
- Review navigation menu and display `ZA` links when viewing one of the ZA pages
- Create new redirect rules for visitors from ZA. e.g. Visiting `/english/about_us` from South africa should redirect to `/english/za/about_us`
- Mobile navigation had `Insvestment` menu instead of `Prices` - Fixed that.

@tochman @AmberWilkie ready for review.